### PR TITLE
fix(quadxhover): fix dense reward bug

### DIFF
--- a/PyFlyt/gym_envs/quadx_envs/quadx_hover_env.py
+++ b/PyFlyt/gym_envs/quadx_envs/quadx_hover_env.py
@@ -98,7 +98,7 @@ class QuadXHoverEnv(QuadXBaseEnv):
         """Computes the termination, truncation, and reward of the current timestep."""
         super().compute_base_term_trunc_reward()
 
-        if self.sparse_reward:
+        if not self.sparse_reward:
             # distance from 0, 0, 1 hover point
             linear_distance = np.linalg.norm(
                 self.env.state(0)[-1] - np.array([0.0, 0.0, 1.0])


### PR DESCRIPTION
This pull request ensures that the dense reward is applied, as explained in the [paper](https://arxiv.org/abs/2304.01305). The old behaviour does not give a dense reward when the user sets `sparse` reward to `False`.

https://github.com/jjshoots/PyFlyt/blob/0b4e89550680c153d8650ada6f6a58362c60f579/PyFlyt/gym_envs/quadx_envs/quadx_hover_env.py#L101C9-L110