### PR TITLE
Fix None error in obj_collision function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # vim
 .vim/
 
+# vscode
+.vscode/
+
 # pypi credentials
 .pyirc
 

--- a/PyFlyt/core/utils/load_objs.py
+++ b/PyFlyt/core/utils/load_objs.py
@@ -81,9 +81,15 @@ def obj_collision(
         meshScale (list[float] | np.ndarray): meshScale
         concave (bool): Whether the object should use concave trimesh, do not use this for dynamic/moving objects
     """
-    return env.createCollisionShape(
-        shapeType=env.GEOM_MESH,
-        fileName=fileName,
-        meshScale=meshScale,
-        flags=env.GEOM_FORCE_CONCAVE_TRIMESH if concave else None,
+    return (
+        env.createCollisionShape(
+            shapeType=env.GEOM_MESH,
+            fileName=fileName,
+            meshScale=meshScale,
+            flags=env.GEOM_FORCE_CONCAVE_TRIMESH,
+        )
+        if concave
+        else env.createCollisionShape(
+            shapeType=env.GEOM_MESH, fileName=fileName, meshScale=meshScale
+        )
     )


### PR DESCRIPTION
In `obj_collision`, if `concave` is set to false, then it passes `None` into the flags argument for `createCollisionShape`.
This results in the following error:
```
Traceback (most recent call last):
  File "/local/phil/ros2_pyflyt/install/pyflyt_ros2/lib/pyflyt_ros2/pyflyt", line 33, in <module>
    sys.exit(load_entry_point('pyflyt-ros2', 'console_scripts', 'pyflyt')())
  File "/local/phil/ros2_pyflyt/build/pyflyt_ros2/pyflyt_ros2/pyflyt_node.py", line 69, in main
    subscriber = PyFlytSubscriber()
  File "/local/phil/ros2_pyflyt/build/pyflyt_ros2/pyflyt_ros2/pyflyt_node.py", line 12, in __init__
    self.start_simulation()
  File "/local/phil/ros2_pyflyt/build/pyflyt_ros2/pyflyt_ros2/pyflyt_node.py", line 47, in start_simulation
    collisionId = obj_collision(self.env, "/csse/users/pdo66/duck.obj")
  File "/local/phil/miniforge3/envs/ros2_env/lib/python3.10/site-packages/PyFlyt/core/utils/load_objs.py", line 84, in obj_collision
    return env.createCollisionShape(
TypeError: 'NoneType' object cannot be interpreted as an integer
```

I've updated the function to not pass in the `flags` positional arg if `concave` is false, as it is an optional parameter, but does not accept None.