### PR TITLE
Update readme to use v1 instead of v0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Usage is similar to any other Gymnasium and PettingZoo environment:
 import gymnasium
 import PyFlyt.gym_envs # noqa
 
-env = gymnasium.make("PyFlyt/QuadX-Hover-v0", render_mode="human")
+env = gymnasium.make("PyFlyt/QuadX-Hover-v1", render_mode="human")
 obs = env.reset()
 
 termination = False


### PR DESCRIPTION
The readme has an example for running the QuadX-Hover environment. This example has v0 in the code. This PR updates the PR so it works off the bat without having to make the minor change.