### PR TITLE
Skip some camera updates to reach a higher RTF

### DIFF
--- a/PyFlyt/core/aviary.py
+++ b/PyFlyt/core/aviary.py
@@ -49,6 +49,7 @@ class Aviary(bullet_client.BulletClient):
         render: bool = False,
         physics_hz: int = 240,
         world_scale: float = 1.0,
+        camera_update_skip: int = 4,
         seed: None | int = None,
     ):
         """Initializes a PyBullet environment that hosts UAVs and other entities.
@@ -109,6 +110,9 @@ class Aviary(bullet_client.BulletClient):
         # default physics looprate is 240 Hz
         self.physics_hz = physics_hz
         self.physics_period = 1.0 / physics_hz
+        # update the camera waste time (~16ms),
+        # so we can skip some camera updates
+        self.camera_update_skip = camera_update_skip
 
         # mapping of drone type string to the constructors
         self.drone_type_mappings = dict()
@@ -466,6 +470,8 @@ class Aviary(bullet_client.BulletClient):
             self.elapsed_time = self.physics_steps / self.physics_hz
 
         # update the last components of the drones, this is usually limited to cameras only
-        [drone.update_last() for drone in self.armed_drones]
+        # update once in some steps
+        if self.aviary_steps % self.camera_update_skip == 0:
+            [drone.update_last() for drone in self.armed_drones]
 
         self.aviary_steps += 1


### PR DESCRIPTION
Based on the discussions in issue #42, here is a minor improvement.

The camera update consumes a significant amount of time (~16ms) and has become a bottleneck, causing the simulation RTF (real-time factor) to always be below 0.5. We observed that every control step (120Hz) calls a camera update, taking up 1920ms of CPU time (ideally, it should be under 1000ms). To address this, we decided to skip some camera steps (the default value was set to 4), which helps ensure an RTF close to 1.