### PR TITLE
fix QuadX manual (-1) mode

### DIFF
--- a/PyFlyt/core/drones/quadx.py
+++ b/PyFlyt/core/drones/quadx.py
@@ -430,7 +430,7 @@ class QuadX(DroneClass):
 
         # controller -1 means just direct to motor pwm commands
         if mode == -1:
-            self.pwm = np.array([*a_output, z_output])
+            self.pwm = np.array([*a_output, *z_output])
             return
 
         # base level controllers


### PR DESCRIPTION
This PR fixes a bug that blocks the usage of manual control for a `QuadX` drone. Example usage (based on `examples/core/05_custom_controller.py`):

```
import numpy as np

from PyFlyt.core import Aviary
from PyFlyt.core.abstractions import ControlClass


class CustomController(ControlClass):
    """A custom controller that inherits from the ControlClass."""

    def __init__(self):
        """Initialize the controller here."""
        pass

    def reset(self):
        """Reset the internal state of the controller here."""
        pass

    def step(self, state: np.ndarray, setpoint: np.ndarray):
        """Step the controller here.

        Args:
            state (np.ndarray): Current state of the UAV
            setpoint (np.ndarray): Desired setpoint

        """
        # outputs a command to base flight mode -1 that makes the drone motors go random throttle values from .295 to .315
        return np.random.uniform(low=.295, high=.315, size=4)


# the starting position and orientations
start_pos = np.array([[0.0, 0.0, 1.0]])
start_orn = np.array([[0.0, 0.0, 0.0]])

# environment setup
env = Aviary(start_pos=start_pos, start_orn=start_orn, render=True, drone_type="quadx")

# register our custom controller for the first drone, this controller is id 8, and is based off -1
env.drones[0].register_controller(
    controller_constructor=CustomController, controller_id=8, base_mode=-1
)

# set to our new custom controller
env.set_mode(8)

# run the sim
for i in range(1000):
    env.step()
```